### PR TITLE
feat: show unsaved changes warning when navigating away with unsaved input 

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -150,9 +150,6 @@ export default function Home() {
       setSection3Bullets(prev => [...prev, section3CurrentInput.trim()]);
       setSection3CurrentInput('');
     }
-    
-    // Set the pending action to execute after state updates
-    // (will be handled in useEffect)
   };
 
   // Handle unsaved changes modal cancellation


### PR DESCRIPTION
## description

Previously, the unsaved changes modal only appeared when clicking "Generate Markdown". Now it also triggers when navigating away from the form (e.g., clicking Settings) with unsaved bullet point input.

Change button label from "Go Back" to "Keep Editing" 