### PR TITLE
improve: standup update rollover detection and functionality 

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -442,22 +442,16 @@ export default function Home() {
     let todaySection = null;
     let yesterdaySection = null;
     
-    // Check all combinations, prioritizing visible sections
-    // For "today" - check in order, but prefer visible sections
+    // Check visible sections only - hidden sections don't participate in rollover
+    // For "today" - check in order
     if (header1IsToday && showSection1) todaySection = 1;
     else if (header2IsToday && showSection2) todaySection = 2;
     else if (header3IsToday && showSection3) todaySection = 3;
-    else if (header1IsToday) todaySection = 1;
-    else if (header2IsToday) todaySection = 2;
-    else if (header3IsToday) todaySection = 3;
     
-    // For "yesterday" - check in order, but prefer visible sections
+    // For "yesterday" - check in order
     if (header1IsYesterday && showSection1) yesterdaySection = 1;
     else if (header2IsYesterday && showSection2) yesterdaySection = 2;
     else if (header3IsYesterday && showSection3) yesterdaySection = 3;
-    else if (header1IsYesterday) yesterdaySection = 1;
-    else if (header2IsYesterday) yesterdaySection = 2;
-    else if (header3IsYesterday) yesterdaySection = 3;
     
     // If we couldn't detect both, return null to indicate rollover not available
     if (todaySection === null || yesterdaySection === null) {


### PR DESCRIPTION
## description

Previously, rollover detection only checked sections 1 and 2, and when multiple sections had the same header (e.g., two "Yesterday" sections), it would always pick the first one even if hidden.

Now properly:
- Detects today/yesterday headers across all three sections
- Prioritizes visible sections when multiple sections match
- Shows rollover button when both detected sections are visible

Fixes issue where Yesterday (hidden), Yesterday (visible), Today (visible) configuration would not show the rollover button.

## tested

### case: yesterday, yesterday, today 
result:

### case: yesterday(visible), today(hidden), today (visible) 
result:  rolled over the current today (visible) to yesterday (expected and wanted behavior)