### PR TITLE
Add parse and rollover button to standup update

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -651,6 +651,63 @@ export default function Home() {
     }
   };
 
+  // Handle parse and rollover - parses the pasted update and rolls "Today" to "Yesterday"
+  const handleParseAndRollover = (parsedData: ParsedUpdateData) => {
+    // Feature only available in super mode
+    if (!superMode) return;
+
+    const { todaySection, yesterdaySection } = detectSections();
+    
+    // Get the "Today" content from the parsed data and put it into "Yesterday"
+    // The parsed section1 contains what was labeled "Today" (or similar) in the pasted update
+    // We need to move that to our current "Yesterday" section
+    
+    if (todaySection === 1 && yesterdaySection === 2) {
+      // Section 1 is Today, Section 2 is Yesterday
+      // Move parsed section1 (Today from paste) to section2 (our Yesterday)
+      setSection2Bullets(parsedData.section1.bullets);
+      setSection1Bullets([]); // Clear Today for new input
+      setSection3Bullets(parsedData.section3.bullets); // Keep blockers from paste
+    } else if (todaySection === 2 && yesterdaySection === 1) {
+      // Section 2 is Today, Section 1 is Yesterday
+      // Move parsed section2 (Today from paste) to section1 (our Yesterday)
+      setSection1Bullets(parsedData.section2.bullets);
+      setSection2Bullets([]); // Clear Today for new input
+      setSection3Bullets(parsedData.section3.bullets); // Keep blockers from paste
+    }
+
+    // Clear any text
+    setSection1Text('');
+    setSection2Text('');
+    setSection3Text('');
+
+    // Clear deletion history since we're replacing content
+    setDeletionHistory([]);
+
+    // Update headers if different ones were detected (only for yesterday section)
+    if (todaySection === 1 && yesterdaySection === 2) {
+      if (parsedData.section1.detectedHeader) {
+        // The detected header was for "Today" in the paste, keep our current header2
+      }
+    } else {
+      if (parsedData.section2.detectedHeader) {
+        // The detected header was for "Today" in the paste, keep our current header1
+      }
+    }
+    if (parsedData.section3.detectedHeader) {
+      setHeader3(parsedData.section3.detectedHeader);
+    }
+
+    // Reset output state
+    setShowOutput(false);
+    setMarkdownOutput('');
+
+    toast({
+      title: "Rollover Complete!",
+      description: "Previous \"Today\" items have been rolled over to \"Yesterday\". Ready for your new update.",
+    });
+  };
+
   const applyPastedData = (parsedData: ParsedUpdateData) => {
     // Use bullets from parsed data
     setSection1Bullets(parsedData.section1.bullets);
@@ -1117,6 +1174,7 @@ export default function Home() {
         isOpen={showPasteModal}
         onClose={() => setShowPasteModal(false)}
         onPaste={handlePasteUpdate}
+        onParseAndRollover={handleParseAndRollover}
         header1={header1}
         header2={header2}
         header3={header3}

--- a/components/PasteUpdateModal.tsx
+++ b/components/PasteUpdateModal.tsx
@@ -10,6 +10,7 @@ interface PasteUpdateModalProps {
   isOpen: boolean;
   onClose: () => void;
   onPaste: (parsedData: ParsedUpdateData) => void;
+  onParseAndRollover: (parsedData: ParsedUpdateData) => void;
   header1: string;
   header2: string;
   header3: string;
@@ -37,6 +38,7 @@ export function PasteUpdateModal({
   isOpen,
   onClose,
   onPaste,
+  onParseAndRollover,
   header1,
   header2,
   header3,
@@ -218,6 +220,15 @@ export function PasteUpdateModal({
     onClose();
   };
 
+  const handleParseAndRollover = () => {
+    if (!pastedText.trim()) return;
+
+    const parsedData = parseUpdate(pastedText);
+    onParseAndRollover(parsedData);
+    setPastedText('');
+    onClose();
+  };
+
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50" onClick={onClose}>
       <Card className="w-full max-w-2xl max-h-[80vh] flex flex-col" onClick={(e) => e.stopPropagation()}>
@@ -267,11 +278,19 @@ export function PasteUpdateModal({
             </ul>
           </div>
 
-          <div className="flex gap-2 justify-end">
-            <Button variant="outline" onClick={onClose}>
+          <div className="flex flex-col sm:flex-row gap-2 sm:justify-end">
+            <Button variant="outline" onClick={onClose} className="min-h-[44px] sm:min-h-0">
               Cancel
             </Button>
-            <Button onClick={handlePaste} disabled={!pastedText.trim()}>
+            <Button 
+              variant="outline"
+              onClick={handleParseAndRollover} 
+              disabled={!pastedText.trim()}
+              className="min-h-[44px] sm:min-h-0"
+            >
+              Parse & Rollover
+            </Button>
+            <Button onClick={handlePaste} disabled={!pastedText.trim()} className="min-h-[44px] sm:min-h-0">
               Parse & Fill Sections
             </Button>
           </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "my-app",
+  "name": "gmatcha",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "my-app",
+      "name": "gmatcha",
       "version": "0.1.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
## Description
Adds a "Parse & Rollover" button to the Paste Update Modal. This button parses the pasted standup update, moves the content that was "Today" in the pasted text to "Yesterday" in the current form, clears "Today" for new input, and preserves "Blockers". This streamlines the process of updating standups by automating the rollover of items.

### Before
The Paste Update Modal had "Cancel" and "Parse & Fill Sections" buttons.

### After
The Paste Update Modal now includes a new "Parse & Rollover" button between "Cancel" and "Parse & Fill Sections".

---
<a href="https://cursor.com/background-agent?bcId=bc-1151bf75-4343-46e8-9ea7-0bd0e37cecf2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1151bf75-4343-46e8-9ea7-0bd0e37cecf2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

