### PR TITLE
feat: add /api/standup formatter endpoint for CLI and AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ speedrun writing your standup update
 - **reset functionality**: easily clear form data or reset all settings to app defaults
 - **local-only storage**: nothing is pushed to a database
 - **rollover**: roll today's section into yesterday's section for the following day's standup update
+- **formatter api**: hit `/api/standup` from the command line or an ai agent to format an update without opening the app
 
 ## getting started
 
@@ -30,3 +31,26 @@ npm run dev
 open: 
 
 [http://localhost:3000](http://localhost:3000)
+
+## api
+
+format a standup without opening the app — send structured sections, get back paste-ready markdown for Slack. deterministic, no auth, nothing is stored.
+
+```bash
+curl -s https://gmatcha.com/api/standup \
+  -H 'Content-Type: application/json' \
+  -d '{"sections":[{"header":"Yesterday","bullets":["shipped the release"]},{"header":"Today","bullets":["code review"]}]}'
+```
+
+returns:
+
+```json
+{ "markdown": "Yesterday\n- shipped the release\n\nToday\n- code review\n\n" }
+```
+
+- `header`: section title; `format`: header style (`none` | `bold` | `##` | `###`, default `none`)
+- `bullets`: array of strings rendered as `- item` lines, or pass `text` for a preformatted body
+- `wrapInCodeBlock: true` wraps the output in a code block so the markdown pastes literally into Slack
+- `GET /api/standup` returns machine-readable usage docs (also described in [/llms.txt](https://gmatcha.com/llms.txt))
+
+works with ai agents too — tell claude code: "summarize today's work as standup bullets, post them to https://gmatcha.com/api/standup, and give it to me in markdown to paste to my team"

--- a/app/api/standup/route.ts
+++ b/app/api/standup/route.ts
@@ -1,0 +1,155 @@
+import { NextResponse } from 'next/server';
+import {
+  HEADER_FORMATS,
+  buildStandupMarkdown,
+  formatBullets,
+  wrapMarkdownWithCodeBlock,
+  type RenderableSection,
+} from '@/lib/standup';
+
+const MAX_BODY_BYTES = 100_000;
+const MAX_SECTIONS = 20;
+const MAX_BULLETS_PER_SECTION = 200;
+const MAX_HEADER_LENGTH = 500;
+const MAX_TEXT_LENGTH = 20_000;
+
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type',
+};
+
+const USAGE = {
+  name: 'gmatcha standup formatter',
+  description:
+    'Deterministic formatter that turns structured standup sections into paste-ready markdown for Slack. No auth, no storage — your content is formatted, returned, and forgotten.',
+  endpoint: 'POST https://gmatcha.com/api/standup',
+  contentType: 'application/json',
+  request: {
+    sections: [
+      {
+        header: 'string — section title, e.g. "Yesterday", "Today", "Blockers"',
+        format: `optional string — markdown style for the header: ${HEADER_FORMATS.map(format => `"${format}"`).join(' | ')} (default "none")`,
+        bullets: 'optional string[] — rendered as "- item" lines',
+        text: 'optional string — preformatted body, used when bullets are not provided',
+      },
+    ],
+    wrapInCodeBlock:
+      'optional boolean — wrap the result in a ``` code block so the markdown pastes literally into Slack (default false)',
+  },
+  response: {
+    markdown: 'string — the formatted standup, ready to paste',
+  },
+  example: {
+    curl: 'curl -s https://gmatcha.com/api/standup -H \'Content-Type: application/json\' -d \'{"sections":[{"header":"Yesterday","bullets":["shipped the release"]},{"header":"Today","bullets":["code review","pairing session"]}]}\'',
+  },
+  limits: {
+    maxBodyBytes: MAX_BODY_BYTES,
+    maxSections: MAX_SECTIONS,
+    maxBulletsPerSection: MAX_BULLETS_PER_SECTION,
+    maxHeaderLength: MAX_HEADER_LENGTH,
+    maxTextLength: MAX_TEXT_LENGTH,
+  },
+};
+
+function badRequest(error: string, status = 400) {
+  return NextResponse.json(
+    { error, hint: 'GET https://gmatcha.com/api/standup returns usage docs' },
+    { status, headers: CORS_HEADERS }
+  );
+}
+
+export async function OPTIONS() {
+  return new NextResponse(null, { status: 204, headers: CORS_HEADERS });
+}
+
+export async function GET() {
+  return NextResponse.json(USAGE, { headers: CORS_HEADERS });
+}
+
+export async function POST(request: Request) {
+  const raw = await request.text();
+  if (raw.length > MAX_BODY_BYTES) {
+    return badRequest(`Request body exceeds ${MAX_BODY_BYTES} bytes`, 413);
+  }
+
+  let body: unknown;
+  try {
+    body = JSON.parse(raw);
+  } catch {
+    return badRequest('Request body must be valid JSON');
+  }
+
+  if (typeof body !== 'object' || body === null || Array.isArray(body)) {
+    return badRequest('Request body must be a JSON object');
+  }
+
+  const { sections, wrapInCodeBlock } = body as Record<string, unknown>;
+
+  if (!Array.isArray(sections) || sections.length === 0) {
+    return badRequest('"sections" must be a non-empty array');
+  }
+  if (sections.length > MAX_SECTIONS) {
+    return badRequest(`"sections" must have at most ${MAX_SECTIONS} items`);
+  }
+  if (wrapInCodeBlock !== undefined && typeof wrapInCodeBlock !== 'boolean') {
+    return badRequest('"wrapInCodeBlock" must be a boolean');
+  }
+
+  const rendered: RenderableSection[] = [];
+  for (let i = 0; i < sections.length; i++) {
+    const section: unknown = sections[i];
+    if (typeof section !== 'object' || section === null || Array.isArray(section)) {
+      return badRequest(`sections[${i}] must be an object`);
+    }
+
+    const { header, format, bullets, text } = section as Record<string, unknown>;
+
+    if (header !== undefined && typeof header !== 'string') {
+      return badRequest(`sections[${i}].header must be a string`);
+    }
+    if (typeof header === 'string' && header.length > MAX_HEADER_LENGTH) {
+      return badRequest(`sections[${i}].header must be at most ${MAX_HEADER_LENGTH} characters`);
+    }
+    if (
+      format !== undefined &&
+      (typeof format !== 'string' || !(HEADER_FORMATS as readonly string[]).includes(format))
+    ) {
+      return badRequest(`sections[${i}].format must be one of: ${HEADER_FORMATS.join(', ')}`);
+    }
+    if (bullets !== undefined) {
+      if (!Array.isArray(bullets) || bullets.some(bullet => typeof bullet !== 'string')) {
+        return badRequest(`sections[${i}].bullets must be an array of strings`);
+      }
+      if (bullets.length > MAX_BULLETS_PER_SECTION) {
+        return badRequest(`sections[${i}].bullets must have at most ${MAX_BULLETS_PER_SECTION} items`);
+      }
+    }
+    if (text !== undefined && typeof text !== 'string') {
+      return badRequest(`sections[${i}].text must be a string`);
+    }
+    if (typeof text === 'string' && text.length > MAX_TEXT_LENGTH) {
+      return badRequest(`sections[${i}].text must be at most ${MAX_TEXT_LENGTH} characters`);
+    }
+
+    const bulletList = (bullets as string[] | undefined) ?? [];
+    const content =
+      bulletList.length > 0 ? formatBullets(bulletList) : ((text as string | undefined) ?? '').trim();
+
+    rendered.push({
+      header: (header as string | undefined) ?? '',
+      format: (format as string | undefined) ?? 'none',
+      content,
+    });
+  }
+
+  const markdown = buildStandupMarkdown(rendered);
+  if (!markdown.trim()) {
+    return badRequest('No content to format — provide at least one section with bullets or text');
+  }
+
+  return NextResponse.json(
+    { markdown: wrapInCodeBlock === true ? wrapMarkdownWithCodeBlock(markdown) : markdown },
+    { headers: CORS_HEADERS }
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useRef } from 'react';
+import { buildStandupMarkdown, formatBullets, wrapMarkdownWithCodeBlock } from '@/lib/standup';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
@@ -352,29 +353,13 @@ export default function Home() {
   }, [section1Bullets, section2Bullets, section3Bullets, pendingAction]);
 
   const generateMarkdownForced = () => {
-    const formatHeader = (format: string, header: string) => {
-      switch (format) {
-        case 'bold':
-          return `**${header}**`;
-        case '##':
-          return `## ${header}`;
-        case '###':
-          return `### ${header}`;
-        case 'none':
-        default:
-          return header;
-      }
-    };
-
     const formatContent = (content: string, bullets: string[]) => {
       if (superMode && bullets.length > 0) {
-        return bullets.map(bullet => `- ${bullet}`).join('\n');
+        return formatBullets(bullets);
       }
       return content.trim();
     };
-    
-    let markdown = '';
-    
+
     const sections = [
       {
         num: 1,
@@ -400,13 +385,12 @@ export default function Home() {
     ];
     
     // Generate markdown in the order specified by sectionOrder
-    for (const sectionNum of sectionOrder) {
-      const section = sections.find(s => s.num === sectionNum);
-      if (section && section.show && section.content) {
-        markdown += `${formatHeader(section.format, section.header)}\n${section.content}\n\n`;
-      }
-    }
-    
+    const orderedSections = sectionOrder
+      .map(sectionNum => sections.find(s => s.num === sectionNum))
+      .filter((section): section is NonNullable<typeof section> => !!section && section.show);
+
+    let markdown = buildStandupMarkdown(orderedSections);
+
     if (!markdown.trim()) {
       markdown = "# Daily Standup\n\nPlease fill in at least one field to generate your standup.";
     }
@@ -439,8 +423,8 @@ export default function Home() {
 
   const copyToClipboard = async () => {
     try {
-      const textToCopy = wrapWithCodeBlock 
-        ? `\`\`\`\n${markdownOutput}\`\`\``
+      const textToCopy = wrapWithCodeBlock
+        ? wrapMarkdownWithCodeBlock(markdownOutput)
         : markdownOutput;
       await navigator.clipboard.writeText(textToCopy);
       toast({

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,10 @@
+import type { MetadataRoute } from 'next';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+    },
+  };
+}

--- a/lib/standup.ts
+++ b/lib/standup.ts
@@ -1,0 +1,40 @@
+export const HEADER_FORMATS = ['none', 'bold', '##', '###'] as const;
+export type HeaderFormat = (typeof HEADER_FORMATS)[number];
+
+export interface RenderableSection {
+  header: string;
+  format: string;
+  content: string;
+}
+
+export function formatHeader(format: string, header: string): string {
+  switch (format) {
+    case 'bold':
+      return `**${header}**`;
+    case '##':
+      return `## ${header}`;
+    case '###':
+      return `### ${header}`;
+    case 'none':
+    default:
+      return header;
+  }
+}
+
+export function formatBullets(bullets: string[]): string {
+  return bullets.map(bullet => `- ${bullet}`).join('\n');
+}
+
+export function buildStandupMarkdown(sections: RenderableSection[]): string {
+  let markdown = '';
+  for (const section of sections) {
+    if (section.content) {
+      markdown += `${formatHeader(section.format, section.header)}\n${section.content}\n\n`;
+    }
+  }
+  return markdown;
+}
+
+export function wrapMarkdownWithCodeBlock(markdown: string): string {
+  return `\`\`\`\n${markdown}\`\`\``;
+}

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,34 @@
+# gmatcha
+
+> gmatcha (https://gmatcha.com) helps you speedrun writing your daily standup update. The web app keeps all data in the browser's localStorage — no accounts, nothing stored server-side.
+
+## Standup formatter API
+
+Deterministic formatter for standup updates: send structured sections as JSON, get back paste-ready markdown for Slack. No auth, no storage — content is formatted, returned, and forgotten.
+
+- Endpoint: POST https://gmatcha.com/api/standup
+- Content-Type: application/json
+- Docs: GET https://gmatcha.com/api/standup returns machine-readable usage docs
+
+Request body:
+
+- sections: array of section objects, each with:
+  - header: string section title (e.g. "Yesterday", "Today", "Blockers")
+  - format: optional markdown style for the header — "none" | "bold" | "##" | "###" (default "none")
+  - bullets: optional array of strings, rendered as "- item" lines
+  - text: optional preformatted string body, used when bullets are not provided
+- wrapInCodeBlock: optional boolean — wraps the result in a ``` code block so the markdown pastes literally into Slack (default false)
+
+Response: { "markdown": "..." }
+
+Sections with no bullets and no text are omitted from the output.
+
+Example:
+
+curl -s https://gmatcha.com/api/standup \
+  -H 'Content-Type: application/json' \
+  -d '{"sections":[{"header":"Yesterday","bullets":["shipped the release"]},{"header":"Today","bullets":["code review"]},{"header":"Blockers","bullets":[]}]}'
+
+## Using from an AI agent (e.g. Claude Code)
+
+Summarize the user's work into short bullet points, POST them to https://gmatcha.com/api/standup with sections like "Yesterday" / "Today" / "Blockers", and return the "markdown" field from the response so the user can paste it to their team.


### PR DESCRIPTION
## What

A **stateless, deterministic formatter API** so people can hit gmatcha.com from their Claude Code CLI (or any terminal/agent) with their updates and get back paste-ready markdown for their team. The caller's agent does the thinking (summarizing work into bullets); gmatcha just formats — no LLM server-side, no auth, no storage. Content is formatted, returned, and forgotten, in keeping with gmatcha's local-only philosophy.

### `POST /api/standup`

```bash
curl -s https://gmatcha.com/api/standup \
  -H 'Content-Type: application/json' \
  -d '{"sections":[{"header":"Yesterday","bullets":["shipped the release"]},{"header":"Today","bullets":["code review"]}]}'
```

```json
{ "markdown": "Yesterday\n- shipped the release\n\nToday\n- code review\n\n" }
```

- `sections[]`: `header`, `format` (`none` | `bold` | `##` | `###`, default `none`), and `bullets[]` or `text`
- `wrapInCodeBlock`: wraps output in a code block so markdown pastes literally into Slack (default false — same default as the web app)
- Empty sections are omitted, same as the web UI
- `GET /api/standup` returns machine-readable usage docs, so an agent that hits it blind learns how to call it
- CORS enabled; input validation with helpful per-field errors; 100 KB body cap

### Also in this PR

- **`lib/standup.ts`**: the markdown generation logic extracted from `page.tsx` and now shared by the web UI and the API — one formatter, output can't drift
- **`public/llms.txt`**: describes the site + API contract for AI agents
- **`app/robots.ts`**: generates an allow-all `/robots.txt`
- **README**: API section with curl example and a suggested Claude Code prompt

## Notes

- The site was previously fully static; this adds one serverless function on Vercel (`ƒ /api/standup`). The main page remains static.
- Web UI behavior is unchanged — the refactor is a mechanical extraction (same output byte-for-byte, including the code-block wrap used by copy-to-clipboard).

## Verification

- ✅ `npm run build` — page still static, `/api/standup` + `/robots.txt` registered
- ✅ Live-tested against `next start`: happy path (bullets), `text` mode, header formats, `wrapInCodeBlock`, invalid JSON → 400, bad `format` value → 400 with field-level error, all-empty → 400, GET docs, `/robots.txt`, `/llms.txt`, CORS preflight → 204 with `access-control-allow-origin: *`
- ✅ `npm run lint` — 0 errors (2 pre-existing warnings, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)