### PR TITLE
feat: add agent prompt banner with copy button

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,6 +20,8 @@ import { ConfirmationModal } from '../components/ConfirmationModal';
 import { PasteUpdateModal, ParsedUpdateData } from '../components/PasteUpdateModal';
 import html2canvas from 'html2canvas';
 
+const AGENT_PROMPT = `Write my standup update: look at my recent work (e.g. git commits, changed files, our conversation) and summarize what I did on my last working day and what I'm working on today as short bullet points. Then POST them as JSON to https://gmatcha.com/api/standup with a body like {"sections":[{"header":"Yesterday","bullets":["..."]},{"header":"Today","bullets":["..."]},{"header":"Blockers","bullets":["..."]}]} (GET that URL for usage docs) and reply with the "markdown" field from the response so I can paste it to my team.`;
+
 export default function Home() {
   const [section1Text, setSection1Text] = useState('');
   const [section2Text, setSection2Text] = useState('');
@@ -442,6 +444,22 @@ export default function Home() {
     }
   };
 
+  const copyAgentPrompt = async () => {
+    try {
+      await navigator.clipboard.writeText(AGENT_PROMPT);
+      toast({
+        title: "Prompt copied!",
+        description: "Paste it into your agent and it will write your standup update",
+      });
+    } catch {
+      toast({
+        title: "Error",
+        description: "Failed to copy to clipboard",
+        variant: "destructive",
+      });
+    }
+  };
+
   const generateImage = async () => {
     setIsGeneratingImage(true);
     try {
@@ -771,6 +789,22 @@ export default function Home() {
         <p className="text-muted-foreground text-pretty text-sm sm:text-base">
           Write out your standup for easy copy and paste
         </p>
+      </div>
+
+      <div className="max-w-2xl mx-auto flex items-center justify-between gap-3 rounded-lg border bg-muted/50 px-4 py-3">
+        <p className="text-sm text-muted-foreground text-left text-pretty">
+          <span className="font-medium text-foreground">Using an AI agent?</span>{' '}
+          Copy this prompt into your terminal and it will write your standup update for you.
+        </p>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={copyAgentPrompt}
+          className="min-h-[44px] sm:min-h-0 min-w-[44px] px-3 shrink-0"
+        >
+          <Copy className="w-4 h-4 sm:mr-2" />
+          <span className="hidden sm:inline">Copy Prompt</span>
+        </Button>
       </div>
 
       {!showOutput ? (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,7 +20,7 @@ import { ConfirmationModal } from '../components/ConfirmationModal';
 import { PasteUpdateModal, ParsedUpdateData } from '../components/PasteUpdateModal';
 import html2canvas from 'html2canvas';
 
-const AGENT_PROMPT = `Write my standup update: look at my recent work (e.g. git commits, changed files, our conversation) and summarize what I did on my last working day and what I'm working on today as short bullet points. Then POST them as JSON to https://gmatcha.com/api/standup with a body like {"sections":[{"header":"Yesterday","bullets":["..."]},{"header":"Today","bullets":["..."]},{"header":"Blockers","bullets":["..."]}]} (GET that URL for usage docs) and reply with the "markdown" field from the response so I can paste it to my team.`;
+const AGENT_PROMPT = `Write my standup update: from my recent work (git commits, our conversation), summarize my last working day and what I'm working on today as short bullets. Then POST them to https://gmatcha.com/api/standup (GET that URL first for usage docs) and reply with the returned markdown to paste to my team, plus the edit url.`;
 
 export default function Home() {
   const [section1Text, setSection1Text] = useState('');


### PR DESCRIPTION
## What

Adds a banner at the top of the app that turns the `/api/standup` endpoint into a user-facing feature: **"Using an AI agent? Copy this prompt into your terminal and it will write your standup update for you."** with a copy button (lucide `Copy` icon).

Clicking copy puts this prompt on the clipboard:

> Write my standup update: from my recent work (git commits, our conversation), summarize my last working day and what I'm working on today as short bullets. Then POST them to https://gmatcha.com/api/standup (GET that URL first for usage docs) and reply with the returned markdown to paste to my team, plus the edit url.

The prompt is deliberately schema-free: the API self-documents (`GET /api/standup` returns usage docs, 400s point to them, `/llms.txt` describes the whole flow), so the agent discovers the request shape itself and the prompt never goes stale as the API evolves. It asks for both the markdown **and the edit url** (#49), so the user gets paste-ready output plus a click-to-edit link.

## Implementation

- `AGENT_PROMPT` module constant — single line so it pastes cleanly into a terminal prompt
- `copyAgentPrompt` handler mirrors the existing `copyToClipboard` pattern (clipboard write + success/error toast)
- Banner sits between the page header and the standup card, `max-w-2xl` to align with the card, muted styling, 44px touch target, icon-only button on mobile

## Verification

- ✅ `npm run build` — clean
- ✅ `npm run lint` — 0 errors
- ✅ Smoke-tested against `next start`: banner text and Copy Prompt button render on `/`
- ✅ The prompt flow itself was dogfooded against production: an agent following it got back correct markdown + edit url

🤖 Generated with [Claude Code](https://claude.com/claude-code)