### PR TITLE
feat: return a share URL from /api/standup that pre-fills the web editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,16 @@ curl -s https://gmatcha.com/api/standup \
 returns:
 
 ```json
-{ "markdown": "Yesterday\n- shipped the release\n\nToday\n- code review\n\n" }
+{
+  "markdown": "Yesterday\n- shipped the release\n\nToday\n- code review\n\n",
+  "url": "https://gmatcha.com/?standup=%7B%22sections%22%3A..."
+}
 ```
 
 - `header`: section title; `format`: header style (`none` | `bold` | `##` | `###`, default `none`)
 - `bullets`: array of strings rendered as `- item` lines, or pass `text` for a preformatted body
 - `wrapInCodeBlock: true` wraps the output in a code block so the markdown pastes literally into Slack
+- the returned `url` opens gmatcha with the standup pre-filled in the web editor, ready to edit
 - `GET /api/standup` returns machine-readable usage docs (also described in [/llms.txt](https://gmatcha.com/llms.txt))
 
 works with ai agents too — tell claude code: "summarize today's work as standup bullets, post them to https://gmatcha.com/api/standup, and give it to me in markdown to paste to my team"

--- a/app/api/standup/route.ts
+++ b/app/api/standup/route.ts
@@ -2,9 +2,11 @@ import { NextResponse } from 'next/server';
 import {
   HEADER_FORMATS,
   buildStandupMarkdown,
+  buildStandupShareUrl,
   formatBullets,
   wrapMarkdownWithCodeBlock,
   type RenderableSection,
+  type StandupPayloadSection,
 } from '@/lib/standup';
 
 const MAX_BODY_BYTES = 100_000;
@@ -12,6 +14,7 @@ const MAX_SECTIONS = 20;
 const MAX_BULLETS_PER_SECTION = 200;
 const MAX_HEADER_LENGTH = 500;
 const MAX_TEXT_LENGTH = 20_000;
+const MAX_SHARE_URL_LENGTH = 8192;
 
 const CORS_HEADERS = {
   'Access-Control-Allow-Origin': '*',
@@ -39,6 +42,7 @@ const USAGE = {
   },
   response: {
     markdown: 'string — the formatted standup, ready to paste',
+    url: 'string — link that opens gmatcha with this standup pre-filled in the web editor (loads the first three sections); omitted for very large payloads',
   },
   example: {
     curl: 'curl -s https://gmatcha.com/api/standup -H \'Content-Type: application/json\' -d \'{"sections":[{"header":"Yesterday","bullets":["shipped the release"]},{"header":"Today","bullets":["code review","pairing session"]}]}\'',
@@ -97,6 +101,7 @@ export async function POST(request: Request) {
   }
 
   const rendered: RenderableSection[] = [];
+  const shareSections: StandupPayloadSection[] = [];
   for (let i = 0; i < sections.length; i++) {
     const section: unknown = sections[i];
     if (typeof section !== 'object' || section === null || Array.isArray(section)) {
@@ -132,15 +137,27 @@ export async function POST(request: Request) {
       return badRequest(`sections[${i}].text must be at most ${MAX_TEXT_LENGTH} characters`);
     }
 
+    const headerValue = (header as string | undefined) ?? '';
+    const formatValue = (format as string | undefined) ?? 'none';
     const bulletList = (bullets as string[] | undefined) ?? [];
-    const content =
-      bulletList.length > 0 ? formatBullets(bulletList) : ((text as string | undefined) ?? '').trim();
+    const textValue = ((text as string | undefined) ?? '').trim();
+    const content = bulletList.length > 0 ? formatBullets(bulletList) : textValue;
 
     rendered.push({
-      header: (header as string | undefined) ?? '',
-      format: (format as string | undefined) ?? 'none',
+      header: headerValue,
+      format: formatValue,
       content,
     });
+
+    const shareSection: StandupPayloadSection = {};
+    if (headerValue) shareSection.header = headerValue;
+    if (formatValue !== 'none') shareSection.format = formatValue;
+    if (bulletList.length > 0) {
+      shareSection.bullets = bulletList;
+    } else if (textValue) {
+      shareSection.text = textValue;
+    }
+    shareSections.push(shareSection);
   }
 
   const markdown = buildStandupMarkdown(rendered);
@@ -148,8 +165,13 @@ export async function POST(request: Request) {
     return badRequest('No content to format — provide at least one section with bullets or text');
   }
 
+  const shareUrl = buildStandupShareUrl({ sections: shareSections }, new URL(request.url).origin);
+
   return NextResponse.json(
-    { markdown: wrapInCodeBlock === true ? wrapMarkdownWithCodeBlock(markdown) : markdown },
+    {
+      markdown: wrapInCodeBlock === true ? wrapMarkdownWithCodeBlock(markdown) : markdown,
+      ...(shareUrl.length <= MAX_SHARE_URL_LENGTH ? { url: shareUrl } : {}),
+    },
     { headers: CORS_HEADERS }
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect, useRef } from 'react';
-import { buildStandupMarkdown, formatBullets, wrapMarkdownWithCodeBlock } from '@/lib/standup';
+import { buildStandupMarkdown, formatBullets, wrapMarkdownWithCodeBlock, parseStandupParam, STANDUP_QUERY_PARAM } from '@/lib/standup';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
@@ -89,6 +89,7 @@ export default function Home() {
   const [showPasteModal, setShowPasteModal] = useState(false);
   const [showPasteConfirmation, setShowPasteConfirmation] = useState(false);
   const [pendingPasteData, setPendingPasteData] = useState<ParsedUpdateData | null>(null);
+  const [pendingPasteSource, setPendingPasteSource] = useState<'paste' | 'link'>('paste');
 
   // Toggle for wrapping with code blocks
   const [wrapWithCodeBlock, setWrapWithCodeBlock] = useState(false);
@@ -638,7 +639,10 @@ export default function Home() {
     }
   };
 
-  const applyPastedData = (parsedData: ParsedUpdateData) => {
+  const applyPastedData = (parsedData: ParsedUpdateData, source: 'paste' | 'link' = 'paste') => {
+    // Incoming content is bullet-shaped, so make sure super mode is on
+    setSuperMode(true);
+
     // Use bullets from parsed data
     setSection1Bullets(parsedData.section1.bullets);
     setSection2Bullets(parsedData.section2.bullets);
@@ -673,25 +677,92 @@ export default function Home() {
                           parsedData.section3.detectedHeader;
 
     toast({
-      title: "Update Pasted!",
-      description: headersUpdated 
-        ? "Your previous update has been loaded and section headers have been updated to match."
-        : "Your previous update has been loaded into the form.",
+      title: source === 'link' ? "Standup loaded!" : "Update Pasted!",
+      description: source === 'link'
+        ? (headersUpdated
+            ? "The standup from your link has been loaded and section headers have been updated to match."
+            : "The standup from your link has been loaded into the form.")
+        : (headersUpdated
+            ? "Your previous update has been loaded and section headers have been updated to match."
+            : "Your previous update has been loaded into the form."),
     });
   };
 
   const handleConfirmPaste = () => {
     if (pendingPasteData) {
-      applyPastedData(pendingPasteData);
+      applyPastedData(pendingPasteData, pendingPasteSource);
       setPendingPasteData(null);
     }
+    setPendingPasteSource('paste');
     setShowPasteConfirmation(false);
   };
 
   const handleCancelPaste = () => {
     setPendingPasteData(null);
+    setPendingPasteSource('paste');
     setShowPasteConfirmation(false);
   };
+
+  // Load a standup from the URL query param (links returned by /api/standup)
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const raw = params.get(STANDUP_QUERY_PARAM);
+    if (raw === null) return;
+
+    // Consume the param so a refresh doesn't re-apply it
+    window.history.replaceState(null, '', window.location.pathname);
+
+    const sections = parseStandupParam(raw);
+    if (!sections || !sections.some(section => section.bullets.length > 0)) {
+      toast({
+        title: "Couldn't load standup from link",
+        description: "The link is missing standup data or the data is malformed.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    const toParsedSection = (index: number) => ({
+      text: '',
+      bullets: sections[index]?.bullets ?? [],
+      detectedHeader: sections[index]?.header,
+    });
+
+    const parsedData: ParsedUpdateData = {
+      section1: toParsedSection(0),
+      section2: toParsedSection(1),
+      section3: toParsedSection(2),
+    };
+
+    // Check saved data directly — state set by the localStorage effect
+    // hasn't committed yet when this effect runs on mount
+    let hasExistingContent = false;
+    try {
+      const savedData = localStorage.getItem('standupFormData');
+      if (savedData) {
+        const saved = JSON.parse(savedData);
+        hasExistingContent = Boolean(
+          (saved.section1Bullets || saved.workingOnBullets || []).length ||
+          (saved.section2Bullets || saved.workedOnYesterdayBullets || []).length ||
+          (saved.section3Bullets || saved.blockersBullets || []).length ||
+          (saved.section1Text || saved.workingOn || '').trim() ||
+          (saved.section2Text || saved.workedOnYesterday || '').trim() ||
+          (saved.section3Text || saved.blockers || '').trim()
+        );
+      }
+    } catch {
+      // Unreadable saved data — treat as no existing content
+    }
+
+    if (hasExistingContent) {
+      setPendingPasteSource('link');
+      setPendingPasteData(parsedData);
+      setShowPasteConfirmation(true);
+    } else {
+      applyPastedData(parsedData, 'link');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const handleDefaultHeaderFormatChange = (newFormat: string) => {
     setDefaultHeaderFormat(newFormat);
@@ -1144,7 +1215,7 @@ export default function Home() {
         title="Replace Existing Content?"
         description={
           <p>
-            You already have content in your standup. Pasting will replace all existing content. Are you sure you want to continue?
+            You already have content in your standup. {pendingPasteSource === 'link' ? 'Loading this link' : 'Pasting'} will replace all existing content. Are you sure you want to continue?
           </p>
         }
         cancelText="Cancel"

--- a/lib/standup.ts
+++ b/lib/standup.ts
@@ -38,3 +38,64 @@ export function buildStandupMarkdown(sections: RenderableSection[]): string {
 export function wrapMarkdownWithCodeBlock(markdown: string): string {
   return `\`\`\`\n${markdown}\`\`\``;
 }
+
+export const STANDUP_QUERY_PARAM = 'standup';
+
+export interface StandupPayloadSection {
+  header?: string;
+  format?: string;
+  bullets?: string[];
+  text?: string;
+}
+
+export interface StandupPayload {
+  sections: StandupPayloadSection[];
+}
+
+export function buildStandupShareUrl(payload: StandupPayload, origin: string): string {
+  return `${origin}/?${STANDUP_QUERY_PARAM}=${encodeURIComponent(JSON.stringify(payload))}`;
+}
+
+export interface ParsedUrlSection {
+  header?: string;
+  bullets: string[];
+}
+
+// Parses the decoded value of the ?standup= query param back into sections.
+// Lenient by design: malformed entries degrade to empty sections, text-only
+// sections are split into bullets, and unknown fields are ignored.
+export function parseStandupParam(raw: string): ParsedUrlSection[] | null {
+  let payload: unknown;
+  try {
+    payload = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!payload || typeof payload !== 'object' || !Array.isArray((payload as { sections?: unknown }).sections)) {
+    return null;
+  }
+
+  return (payload as { sections: unknown[] }).sections.map(section => {
+    if (!section || typeof section !== 'object' || Array.isArray(section)) {
+      return { bullets: [] };
+    }
+    const record = section as Record<string, unknown>;
+    const header =
+      typeof record.header === 'string' && record.header.trim() ? record.header.trim() : undefined;
+
+    let bullets: string[] = [];
+    if (Array.isArray(record.bullets)) {
+      bullets = record.bullets
+        .filter((bullet): bullet is string => typeof bullet === 'string')
+        .map(bullet => bullet.trim())
+        .filter(Boolean);
+    } else if (typeof record.text === 'string') {
+      bullets = record.text
+        .split('\n')
+        .map(line => line.replace(/^\s*[-*•]\s*/, '').trim())
+        .filter(Boolean);
+    }
+
+    return { header, bullets };
+  });
+}

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -19,7 +19,9 @@ Request body:
   - text: optional preformatted string body, used when bullets are not provided
 - wrapInCodeBlock: optional boolean — wraps the result in a ``` code block so the markdown pastes literally into Slack (default false)
 
-Response: { "markdown": "..." }
+Response: { "markdown": "...", "url": "https://gmatcha.com/?standup=..." }
+
+The "url" field is a clickable link that opens gmatcha with the standup pre-filled in the web editor (the editor loads the first three sections), so the user can keep editing it in the UI. It is omitted for very large payloads.
 
 Sections with no bullets and no text are omitted from the output.
 
@@ -31,4 +33,4 @@ curl -s https://gmatcha.com/api/standup \
 
 ## Using from an AI agent (e.g. Claude Code)
 
-Summarize the user's work into short bullet points, POST them to https://gmatcha.com/api/standup with sections like "Yesterday" / "Today" / "Blockers", and return the "markdown" field from the response so the user can paste it to their team.
+Summarize the user's work into short bullet points, POST them to https://gmatcha.com/api/standup with sections like "Yesterday" / "Today" / "Blockers", and return the "markdown" field from the response so the user can paste it to their team. Also share the "url" field so they can open the standup in the gmatcha web editor and tweak it there.


### PR DESCRIPTION
## What

Closes the loop on the agent flow: the API response now includes a **clickable `url`** alongside the markdown, and opening it loads the standup **pre-filled and editable** in the web app UI.

```json
{
  "markdown": "Yesterday\n- shipped the release\n\n## Today\n- code review\n\n",
  "url": "https://gmatcha.com/?standup=%7B%22sections%22%3A..."
}
```

The URL carries the standup as a query-encoded JSON payload (`?standup=<encoded>`), so nothing is stored server-side — the link *is* the data, consistent with gmatcha's local-only philosophy.

## How it works

**API (`/api/standup`)** — builds the URL from the validated sections and the request origin (prod links to gmatcha.com, preview deployments link to themselves). Omitted above 8 KB so returned links stay clickable everywhere; `GET` usage docs updated.

**Web app** — on load, a `?standup=` param is parsed (leniently: text-only sections are split into bullets, malformed jsonk degrades to a friendly error toast) and fed through the **existing paste-update pipeline**:

- loads the first three sections into the editor with their headers
- if you already have content, the same "Replace existing content?" confirmation modal appears (copy adjusted for link loads)
- the param is consumed via `history.replaceState`, so a refresh doesn't re-apply it over your edits
- switches super mode on, since incoming content is bullet-shaped

**Shared** — `buildStandupShareUrl` / `parseStandupParam` live in `lib/standup.ts` next to the formatter, used by both sides.

## Verification

- ✅ Unit-tested the encode→decode roundtrip (compiled `lib/standup.ts`, exact payload match) plus edge cases: bad JSON → null, junk sections degrade to empty, non-string bullets filtered, `text` splits into bullets
- ✅ Live against `next start`: POST returns `url`, decoding it reproduces the sent payload exactly, opening it returns 200, oversized payloads omit `url` while keeping `markdown`
- ✅ `npm run build` clean, `npm run lint` 0 errors
- ⚠️ The in-browser populate path reuses the battle-tested paste pipeline and its parser is unit-tested, but I couldn't click-test a real browser here — worth a quick check on the Vercel preview: POST to the preview URL, open the returned link, confirm the form fills.

## Notes

- The editor has exactly three section slots, so links load the first three sections (the API itself still accepts up to 20). Documented in the usage docs.
- Follow-up idea: update the agent prompt in #48 to also surface the returned `url`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)