### PR TITLE
feat: option to include current standup details in the copied agent prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ your agent summarizes your actual work into bullets, gmatcha formats them, and y
 
 no api key, no setup, nothing stored — the api formats and forgets, and the edit link carries the standup in the url itself.
 
-tip: in the app's banner, tick "include what's currently in my standup details" before copying the prompt — the agent then sees your previous update (your form is saved locally between visits) and can write the new Yesterday section from what you'd planned.
+tip: in the app's banner, tick "include what's currently in my standup details" (it appears once your form has content) before copying the prompt — the agent then sees your previous update (your form is saved locally between visits) and can write the new Yesterday section from what you'd planned.
 
 ## getting started
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ your agent summarizes your actual work into bullets, gmatcha formats them, and y
 
 no api key, no setup, nothing stored — the api formats and forgets, and the edit link carries the standup in the url itself.
 
+tip: in the app's banner, tick "include what's currently in my standup details" before copying the prompt — the agent then sees your previous update (your form is saved locally between visits) and can write the new Yesterday section from what you'd planned.
+
 ## getting started
 
 install dependencies:

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -96,6 +96,9 @@ export default function Home() {
   // Toggle for wrapping with code blocks
   const [wrapWithCodeBlock, setWrapWithCodeBlock] = useState(false);
 
+  // Toggle for including the current standup details in the copied agent prompt
+  const [includePromptDetails, setIncludePromptDetails] = useState(false);
+
   // Falling matcha emoji state
   type FallingEmoji = {
     id: number;
@@ -445,12 +448,50 @@ export default function Home() {
     }
   };
 
+  // Markdown for whatever is currently in the form ('' when empty) — same
+  // section building as generateMarkdownForced, without the placeholder
+  const buildCurrentMarkdown = () => {
+    const formatContent = (content: string, bullets: string[]) => {
+      if (superMode && bullets.length > 0) {
+        return formatBullets(bullets);
+      }
+      return content.trim();
+    };
+
+    const sections = [
+      { num: 1, content: formatContent(section1Text, section1Bullets), header: header1, format: header1Format, show: showSection1 },
+      { num: 2, content: formatContent(section2Text, section2Bullets), header: header2, format: header2Format, show: showSection2 },
+      { num: 3, content: formatContent(section3Text, section3Bullets), header: header3, format: header3Format, show: showSection3 },
+    ];
+
+    const orderedSections = sectionOrder
+      .map(sectionNum => sections.find(s => s.num === sectionNum))
+      .filter((section): section is NonNullable<typeof section> => !!section && section.show);
+
+    return buildStandupMarkdown(orderedSections);
+  };
+
   const copyAgentPrompt = async () => {
+    let prompt = AGENT_PROMPT;
+    let withDetails = false;
+
+    if (includePromptDetails) {
+      const current = buildCurrentMarkdown().trim();
+      if (current) {
+        withDetails = true;
+        prompt += `\n\nFor context, here is my current standup from the gmatcha editor (my previous update) — use it to inform the new update's Yesterday section:\n\n${current}`;
+      }
+    }
+
     try {
-      await navigator.clipboard.writeText(AGENT_PROMPT);
+      await navigator.clipboard.writeText(prompt);
       toast({
         title: "Prompt copied!",
-        description: "Paste it into your agent and it will write your standup update",
+        description: includePromptDetails && !withDetails
+          ? "Your standup is empty, so the prompt was copied without details"
+          : withDetails
+            ? "Prompt copied with your current standup details included"
+            : "Paste it into your agent and it will write your standup update",
       });
     } catch {
       toast({
@@ -863,10 +904,21 @@ export default function Home() {
       </div>
 
       <div className="max-w-2xl mx-auto flex items-center justify-between gap-3 rounded-lg border bg-muted/50 px-4 py-3">
-        <p className="text-sm text-muted-foreground text-left text-pretty">
-          <span className="font-medium text-foreground">Using an AI agent?</span>{' '}
-          Copy this prompt into your terminal and it will write your standup update for you.
-        </p>
+        <div className="space-y-1.5 text-left">
+          <p className="text-sm text-muted-foreground text-pretty">
+            <span className="font-medium text-foreground">Using an AI agent?</span>{' '}
+            Copy this prompt into your terminal and it will write your standup update for you.
+          </p>
+          <label className="flex items-center gap-2 text-xs text-muted-foreground cursor-pointer w-fit">
+            <input
+              type="checkbox"
+              checked={includePromptDetails}
+              onChange={(event) => setIncludePromptDetails(event.target.checked)}
+              className="accent-primary"
+            />
+            include what&apos;s currently in my standup details (helps the agent write the Yesterday section)
+          </label>
+        </div>
         <Button
           variant="outline"
           size="sm"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -487,11 +487,9 @@ export default function Home() {
       await navigator.clipboard.writeText(prompt);
       toast({
         title: "Prompt copied!",
-        description: includePromptDetails && !withDetails
-          ? "Your standup is empty, so the prompt was copied without details"
-          : withDetails
-            ? "Prompt copied with your current standup details included"
-            : "Paste it into your agent and it will write your standup update",
+        description: withDetails
+          ? "Prompt copied with your current standup details included"
+          : "Paste it into your agent and it will write your standup update",
       });
     } catch {
       toast({
@@ -501,6 +499,9 @@ export default function Home() {
       });
     }
   };
+
+  // The include-details checkbox is only offered when there's something to include
+  const hasCurrentStandupDetails = buildCurrentMarkdown().trim() !== '';
 
   const generateImage = async () => {
     setIsGeneratingImage(true);
@@ -909,15 +910,17 @@ export default function Home() {
             <span className="font-medium text-foreground">Using an AI agent?</span>{' '}
             Copy this prompt into your terminal and it will write your standup update for you.
           </p>
-          <label className="flex items-center gap-2 text-xs text-muted-foreground cursor-pointer w-fit">
-            <input
-              type="checkbox"
-              checked={includePromptDetails}
-              onChange={(event) => setIncludePromptDetails(event.target.checked)}
-              className="accent-primary"
-            />
-            include what&apos;s currently in my standup details (helps the agent write the Yesterday section)
-          </label>
+          {hasCurrentStandupDetails && (
+            <label className="flex items-center gap-2 text-xs text-muted-foreground cursor-pointer w-fit">
+              <input
+                type="checkbox"
+                checked={includePromptDetails}
+                onChange={(event) => setIncludePromptDetails(event.target.checked)}
+                className="accent-primary"
+              />
+              include what&apos;s currently in my standup details (helps the agent write the Yesterday section)
+            </label>
+          )}
         </div>
         <Button
           variant="outline"


### PR DESCRIPTION
## What

The agent banner gains a checkbox: **"include what's currently in my standup details (helps the agent write the Yesterday section)"** — shown only when the form actually has content.

When ticked, Copy Prompt appends the form's current content (as markdown) to the prompt:

> …reply with the returned markdown to paste to my team, plus the edit url.
>
> For context, here is my current standup from the gmatcha editor (my previous update) — use it to inform the new update's Yesterday section:
>
> Yesterday
> - …
> Today
> - …

## Why this closes the "yesterday" loop

The form already persists to localStorage between visits, so when you come back the next day, **your previous standup is still sitting in the editor** — including the Today section you wrote yesterday, which is exactly what the agent needs to ground the new update's Yesterday section (plan vs. what your git history says actually happened). This connects that stored context to the terminal flow with one checkbox — no new storage, no accounts, consistent with local-only.

## Details

- Checkbox only renders when the form has content — an empty editor shows the plain banner
- Defaults to off; the base prompt is unchanged when unticked
- `buildCurrentMarkdown()` reuses the shared `lib/standup` formatter for the appended context (same output as Generate, minus the placeholder)
- README's terminal section gains a tip line about the checkbox

## Verification

- ✅ `npm run build` clean, `npm run lint` 0 errors
- ✅ Smoke test: banner renders on `/`; checkbox absent in the empty-form HTML, appears once content exists (state-driven)
- Clipboard content is a client interaction — quick preview check: add a bullet, tick the box, Copy Prompt, paste somewhere and confirm the context block is appended

🤖 Generated with [Claude Code](https://claude.com/claude-code)