### PR TITLE
feat: advertise the one-liner agent flow on the landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ your agent summarizes your actual work into bullets, gmatcha formats them, and y
 
 no api key, no setup, nothing stored — the api formats and forgets, and the edit link carries the standup in the url itself.
 
+don't even want to copy a prompt? a one-liner is enough — gmatcha's [/llms.txt](https://gmatcha.com/llms.txt) and self-documenting api teach your agent the rest:
+
+```text
+write me a standup update using gmatcha.com
+```
+
 ## getting started
 
 install dependencies:

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -863,10 +863,15 @@ export default function Home() {
       </div>
 
       <div className="max-w-2xl mx-auto flex items-center justify-between gap-3 rounded-lg border bg-muted/50 px-4 py-3">
-        <p className="text-sm text-muted-foreground text-left text-pretty">
-          <span className="font-medium text-foreground">Using an AI agent?</span>{' '}
-          Copy this prompt into your terminal and it will write your standup update for you.
-        </p>
+        <div className="space-y-1 text-left">
+          <p className="text-sm text-muted-foreground text-pretty">
+            <span className="font-medium text-foreground">Using an AI agent?</span>{' '}
+            Copy this prompt into your terminal and it will write your standup update for you.
+          </p>
+          <p className="text-xs text-muted-foreground text-pretty">
+            Or just type <code className="rounded bg-background px-1 py-0.5 text-foreground">write me a standup update using gmatcha.com</code> in Claude Code — the site will teach your agent the rest.
+          </p>
+        </div>
         <Button
           variant="outline"
           size="sm"


### PR DESCRIPTION
## What

The agent banner gains a second line:

> Or just type `write me a standup update using gmatcha.com` in Claude Code — the site will teach your agent the rest.

…and the README's terminal section gets the matching note with the one-liner in a code block.

## Why this works with zero prompt engineering

This exact one-liner was tested live in a real Claude Code session: the agent hits gmatcha.com, discovers `/llms.txt` and the self-documenting `GET /api/standup`, summarizes the session's work, POSTs it, and returns the formatted markdown plus the edit link. The infrastructure for agent-discoverability was built in #46/#49 — this PR just tells humans it exists.

The full copy-paste prompt stays as the primary CTA (it's more reliable across different agents and gives more explicit instructions); the one-liner is the "it's really this easy" hook.

## Verification

- ✅ `npm run build` clean, `npm run lint` 0 errors
- ✅ Smoke test: hint line renders on `/` (200)
- ✅ The one-liner flow itself was verified against production earlier (agent → markdown + edit url)

🤖 Generated with [Claude Code](https://claude.com/claude-code)